### PR TITLE
fix token name

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -35,7 +35,7 @@ const App: React.FC = () => {
         <Route
           path="/"
           element={
-            localStorage.getItem("authToken") ? (
+            localStorage.getItem("token") ? (
               <HomePage />
             ) : (
               <Navigate to="/login" replace />


### PR DESCRIPTION
- Fix the name of item in local storage : getting `authToken` instead of `token`